### PR TITLE
Update to version 0.11.7

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@ package:
     version: 0.10.13
 
 source:
-    fn: ruamel.yaml.0.10.13.tar.gz 
+    fn: ruamel.yaml.0.10.13.tar.gz
     url: https://pypi.python.org/packages/source/r/ruamel.yaml/ruamel.yaml-0.10.13.tar.gz
     md5: b75f26de99274d9bc107b02fc4552d31
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.10.13" %}
+{% set version = "0.11.7" %}
 
 package:
     name: ruamel.yaml
@@ -7,7 +7,7 @@ package:
 source:
     fn: ruamel.yaml.{{ version  }}.tar.gz
     url: https://pypi.python.org/packages/source/r/ruamel.yaml/ruamel.yaml-{{ version }}.tar.gz
-    md5: b75f26de99274d9bc107b02fc4552d31
+    md5: 55de477f1d1b5eb17731a7a822b712b6
 
 build:
     script: python setup.py install --single-version-externally-managed --record=record.txt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,10 +1,12 @@
+{% set version = "0.10.13" %}
+
 package:
     name: ruamel.yaml
-    version: 0.10.13
+    version: {{ version }}
 
 source:
-    fn: ruamel.yaml.0.10.13.tar.gz
-    url: https://pypi.python.org/packages/source/r/ruamel.yaml/ruamel.yaml-0.10.13.tar.gz
+    fn: ruamel.yaml.{{ version  }}.tar.gz
+    url: https://pypi.python.org/packages/source/r/ruamel.yaml/ruamel.yaml-{{ version }}.tar.gz
     md5: b75f26de99274d9bc107b02fc4552d31
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,4 +31,5 @@ about:
 
 extra:
     recipe-maintainers:
+         - jakirkham
          - pelson


### PR DESCRIPTION
* Updates to the most recent version of `rumel.yaml` (released 11 days ago).
* Uses jinja templates for the versioning to simplify matters.
* Add self to the maintainers list.
* Drop some trailing whitespace.