### PR TITLE
Add ruamel.ordereddict as a dependency on python 2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     run:
         - python
         - setuptools
+        - ruamel.ordereddict   # [py26 or py27]
 
 test:
     imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     md5: 88e58c8f50c3f471dc3a73e4d603e327
 
 build:
-    number: 0
+    number: 1
     script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:


### PR DESCRIPTION
I was trying out `ruamel.yaml` today and noticed that it depends, on python 26 and 27, on `ruamel.ordereddict` (see [1]). This adds that dependency for those versions of python (I know conda-forge isn't building for py26 so I'm happy to remove that).

[1]: https://bitbucket.org/ruamel/yaml/src/86622a1408e0f171a12e140d53c4ffac4b6caaa3/__init__.py?at=default&fileviewer=file-view-default#__init__.py-17