### PR TITLE
updated v0.17.14

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.17.13" %}
+{% set version = "0.17.14" %}
 
 package:
   name: ruamel.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/r/ruamel.yaml/ruamel.yaml-{{ version }}.tar.gz
-  sha256: 02f0ed93e98ea32498d25a2952635bbd9fabd553599b8ad67724b4ac88dd8f6c
+  sha256: 4185fcfa9e037fea9ffd0bb6172354a03ec98c21e462355d72e068c74e493512
 
 build:
   number: 0


### PR DESCRIPTION
Closes #149, effectively. (Should successfully render a future version, which would only cause problems with a strict pin under Windows.)

Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

Please do NOT rerender. ;) It would break @xhochy's patch.