### PR TITLE
Switch version to 0.18.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 /build_artifacts
 
 *.pyc
+
+# Rattler-build's artifacts are in `output` when not specifying anything.
+/output

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.18.10" %}
+{% set version = "0.18.7" %}
 
 package:
   name: ruamel.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/r/ruamel.yaml/ruamel.yaml-{{ version }}.tar.gz
-  sha256: 20c86ab29ac2153f80a428e1254a8adf686d3383df04490514ca3b79a362db58
+  sha256: 270638acec6659f7bb30f4ea40083c9a0d0d5afdcef5e63d666f11209091531a
 
 build:
   number: 0


### PR DESCRIPTION
**Note: This should not be merged into `main`, but probably pushed to a new `0.18.x` branch. GitHub sadly doesn't allow PRs to target non-existing branches.**

This conda-forge recipe jumped from 0.18.6 straight to 0.18.8, skipping 0.18.7 (https://github.com/conda-forge/ruamel.yaml-feedstock/pull/198)
I am the maintainer of the [check-jsonschema feedstock](https://github.com/conda-forge/check-jsonschema-feedstock/) and one version of this software has a pinned dependency on `ruamel.yaml ==0.18.7`. See upstream here: https://github.com/python-jsonschema/check-jsonschema/compare/0.30.0...0.31.0

Therefore I would need a 0.18.7 release on conda-forge to specify as a dependency.
Thank you very much.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

